### PR TITLE
Fix galaxy lint warnings (#3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - git clone -b ${lint_version} https://github.com/lean-delivery/ansible-lint-rules.git ~/ansible-lint-rules
 
 install:
-  - pip install --upgrade ansible==2.5.* ansible-lint docker-py molecule==2.17 pyOpenSSL PyYAML
+  - pip install --upgrade ansible==2.5.* ansible-lint docker-py molecule==2.17 pyOpenSSL PyYAML pytest==3.7.4
   - ansible --version
 
 script:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,8 +14,8 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
-        - 16.04
-        - 18.04
+        - xenial
+        - bionic
 
   galaxy_tags:
     - development

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,4 +9,4 @@
 
 - name: "Setup npm and install global packages"
   include_tasks: "npm.yml"
-  when: npm_global_user | trim != "" and npm_global_group | trim != ""
+  when: npm_global_user | trim and npm_global_group | trim


### PR DESCRIPTION
* Fix lint warning: invalid platform (#2)

*  Fix lint warning not to compare to empty string (#2)

* Fix travis config not to use broken pytest version